### PR TITLE
Remove name from nimble file, because its not valid. 

### DIFF
--- a/mangle.nimble
+++ b/mangle.nimble
@@ -1,5 +1,4 @@
 # Package
-name          = "mangle"
 version       = "0.1.0"
 author        = "baabelfish"
 description   = "Yet another iterator library"


### PR DESCRIPTION
```
nimble check -n
       Tip: 4 messages have been suppressed, use --verbose to show them.
     Error: Could not validate package:
        ... Could not read package info file in /p/nimwatch/pkgs/mangle/mangle.nimble;
        ...   Reading as ini file failed with: 
        ...     Invalid section: .
        ...   Evaluating as NimScript file failed with: 
        ...     p/nimwatch/pkgs/mangle/mangle.nimble(2, 1) Error: undeclared identifier: 'name'.
```